### PR TITLE
feat: expose on tailscale

### DIFF
--- a/ci/chart/templates/service.yaml
+++ b/ci/chart/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ .Values.name }}
   labels:
     app.kubernetes.io/name: {{ .Values.name }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/ci/chart/values.yaml
+++ b/ci/chart/values.yaml
@@ -11,6 +11,11 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
+service:
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "{{ .Values.name }}"
+
 resources:
   requests:
     cpu: 10m


### PR DESCRIPTION
Adds the annotations for exposing on tailscale via http://mainnet-round-table and http://preview-round-table